### PR TITLE
Optimize cover image

### DIFF
--- a/src/component/podcast.jsx
+++ b/src/component/podcast.jsx
@@ -107,6 +107,7 @@ class Podcast extends Component {
         description={p.description}
         image={`${MESON_ENDPOINT}/${p.cover}`}
         key={p.pid}
+        smallImage={true}
       />
     )
     return podcastHtml

--- a/src/component/podcast_html.jsx
+++ b/src/component/podcast_html.jsx
@@ -112,7 +112,7 @@ export default class PodcastHtml extends Component {
         const { podcastHeight } = this.state
         return (
             <div className={`card text-center h-full ${!this.props.smallImage && "shadow-2xl hover:cursor-pointer hover:border"}`} ref={e => { this.container = e }}>
-                <div className={`px-2 pt-3 md:px-5 md:pt-5 ${this.props.smallImage && "w-2/5 h-auto mx-auto"}`}>
+                <div className={`px-2 pt-3 md:px-5 md:pt-5 w-full h-auto mx-auto ${this.props.smallImage && "md:w-2/5"}`}>
                     <a href={`/#/podcasts/${this.props.link} `}>
                         <figure className="aspect-h-1 aspect-w-1">
                             {/*!this.props.rss && <Badge className="episode-badge" bg="info">{this.episodeCount(this.props.episodes)}</Badge>*/} {/* TODO: stick badge to bounds of cover image, don't guess */}

--- a/src/component/podcast_html.jsx
+++ b/src/component/podcast_html.jsx
@@ -9,7 +9,8 @@ export default class PodcastHtml extends Component {
         super(props)
         this.state = {
             podcastHeight: null,
-            truncated: false
+            truncated: false,
+            smallImage: false,
         }
     }
 
@@ -110,12 +111,12 @@ export default class PodcastHtml extends Component {
         // console.log(this.props.rss)
         const { podcastHeight } = this.state
         return (
-            <div className="card text-center shadow-2xl hover:cursor-pointer hover:border h-full" ref={e => { this.container = e }}>
-                <div className="px-2 pt-3 md:px-5 md:pt-5">
-                    <a href={`/#/podcasts/${this.props.link}`}>
-                        <figure className='aspect-w-10 aspect-h-7'>
+            <div className={`card text-center h-full ${!this.props.smallImage && "shadow-2xl hover:cursor-pointer hover:border"}`} ref={e => { this.container = e }}>
+                <div className={`px-2 pt-3 md:px-5 md:pt-5 ${this.props.smallImage && "w-2/5 h-auto mx-auto"}`}>
+                    <a href={`/#/podcasts/${this.props.link} `}>
+                        <figure className="aspect-h-1 aspect-w-1">
                             {/*!this.props.rss && <Badge className="episode-badge" bg="info">{this.episodeCount(this.props.episodes)}</Badge>*/} {/* TODO: stick badge to bounds of cover image, don't guess */}
-                            <img className="object-cover pointer-events-none group-hover:opacity-75" alt={`${this.props.name} cover`} src={this.props.image} />
+                            <img className="object-cover pointer-events-none group-hover:opacity-75 rounded-xl" alt={`${this.props.name} cover`} src={this.props.image} />
                         </figure>
                     </a>
                 </div>
@@ -126,7 +127,7 @@ export default class PodcastHtml extends Component {
                         {this.props.truncated && this.props.description.length > 52 ? this.props.description.substring(0, 52) + '...' : this.props.description}
                     </p>
                 </div>
-            </div>
+            </div >
         )
     }
 


### PR DESCRIPTION
* Make the image cover square. 
* Reduce the size of the image in individual view.

[demo](https://permacast-ui.herokuapp.com/)